### PR TITLE
feat: Add a message option to override the default warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.5
+* feat: Add a message option to override the default warning message [#11](https://github.com/bamboechop/eslint-plugin-jira-ticket-todo-comment/pull/11)
+
 ## 1.0.4
 * fix: hardcoded `TODO` check
 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ This rule has an optional object option.
     }
 }
 ```
+* `"message": "Please replace this TODO with a JIRA reference."` allows you to override the default message that appears when a TODO is detected without any JIRA key.
+```json
+{
+    "rules": {
+        "jira-ticket-todo-comment/jira-ticket-todo-comment": ["error", { "message":  "Please replace this TODO with a JIRA reference." }]
+    }
+}
+```

--- a/lib/rules/jira-ticket-todo-comment.js
+++ b/lib/rules/jira-ticket-todo-comment.js
@@ -5,6 +5,7 @@ module.exports = {
         const options = context.options[0];
         const projectKey = options && options.projectKey;
         const regexOption = options && options.regex;
+        const messageOption = options && options.message;
         if(projectKey && regexOption) {
           context.report({ messageId: `bothOptionsProvided`, node });
           return;
@@ -19,7 +20,8 @@ module.exports = {
         for(const node of context.getSourceCode().getAllComments()) {
           const value = node.value.trimStart();
           if(value.toLowerCase().startsWith(`todo`) && !regex.test(value)) {
-            context.report({ data: { ticketNumber: `${projectKey ? projectKey : `MP`}-123` }, messageId: `addJiraTicketNumber`, node });
+            const message = messageOption ? { message: messageOption } : { messageId: `addJiraTicketNumber`};
+            context.report({ data: { ticketNumber: `${projectKey ? projectKey : `MP`}-123` }, ...message, node });
           }
         }
       },
@@ -44,6 +46,9 @@ module.exports = {
             type: `string`,
           },
           regex: {
+            type: `string`,
+          },
+          message: {
             type: `string`,
           },
         },

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
     "lint": "eslint .",
     "test": "mocha tests --recursive"
   },
-  "version": "1.0.4"
+  "version": "1.0.5"
 }

--- a/tests/lib/rules/jira-ticket-todo-comment.test.js
+++ b/tests/lib/rules/jira-ticket-todo-comment.test.js
@@ -30,6 +30,10 @@ ruleTester.run(`JIRA ticket TODO comment test`, rule , {
       options: [{ projectKey: `TP` }],
     },
     {
+      code: `// TODO TP-123 fix this`,
+      options: [{ projectKey: `TP`, message: "Please replace this TODO with a JIRA reference." }],
+    },
+    {
       code: `// TODO T_P-123 fix this`,
       options: [{ regex: `^TODO\\s[A-Z]_[A-Z]{1,9}-\\d+\\s?.*` }],
     },


### PR DESCRIPTION
Hey there! Thanks for creating this rule!
What do you think about including an extra optional parameter to overwrite the default error message?

The intention here is so that folks can use this rule to detect TODOs and replace them with JIRA references entirely - so that we can prevent [SonarQube smells appearing later on those TODOs](https://rules.sonarsource.com/javascript/RSPEC-1135/).

If anything else is required feel free to let me know or to go ahead and update this yourself either - cheers!